### PR TITLE
Make file mode a string

### DIFF
--- a/vm/default.pp
+++ b/vm/default.pp
@@ -21,7 +21,7 @@ node 'ubuntucalcite' {
         logoutput => 'on_failure'
     }
 
-    File { owner => 0, group => 0, mode => 0644 }
+    File { owner => 0, group => 0, mode => '0644' }
 
     # Mongo
     # This should install mongodb server and client, in the latest mongodb-org version


### PR DESCRIPTION
Using numerical values for file mode is now an error in Puppet 4+. Using a string should still work in older versions.
