### PR TITLE
Rename Calcite mailing list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,10 +25,10 @@
   <mailingLists>
     <mailingList>
       <name>Apache Calcite developers list</name>
-      <subscribe>dev-subscribe@calcite.incubator.apache.org</subscribe>
-      <unsubscribe>dev-unsubscribe@calcite.incubator.apache.org</unsubscribe>
-      <post>dev@calcite.incubator.apache.org</post>
-      <archive>http://mail-archives.apache.org/mod_mbox/incubator-calcite-dev</archive>
+      <subscribe>dev-subscribe@calcite.apache.org</subscribe>
+      <unsubscribe>dev-unsubscribe@calcite.apache.org</unsubscribe>
+      <post>dev@calcite.apache.org</post>
+      <archive>http://mail-archives.apache.org/mod_mbox/calcite-dev</archive>
     </mailingList>
   </mailingLists>
 


### PR DESCRIPTION
Calcite's mailing list was renamed on graduation.
