### PR TITLE
Cassandra version upgrade to 3.0.3

### DIFF
--- a/twissandra/src/main/resources/dataset/schema.cql
+++ b/twissandra/src/main/resources/dataset/schema.cql
@@ -39,3 +39,9 @@ CREATE TABLE twissandra.timeline (
     tweet_id uuid,
     PRIMARY KEY (username, time)
 ) WITH CLUSTERING ORDER BY (time DESC);
+
+CREATE MATERIALIZED VIEW twissandra.tweets_by_user AS
+    SELECT username, tweet_id
+    FROM twissandra.tweets
+    WHERE username IS NOT NULL
+    PRIMARY KEY (username, tweet_id);

--- a/vm/Vagrantfile
+++ b/vm/Vagrantfile
@@ -41,7 +41,7 @@ Vagrant.configure(2) do |config|
 
       v.customize ['modifyvm', :id, '--name', 'ubuntu1404-calcite']
       v.customize ['modifyvm', :id, '--cpus', '1']
-      v.customize ['modifyvm', :id, '--memory', 512]
+      v.customize ['modifyvm', :id, '--memory', 1024]
       v.customize ['modifyvm', :id, '--ioapic', 'off']
       v.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
       v.customize ['modifyvm', :id, '--nictype1', 'virtio']

--- a/vm/default.pp
+++ b/vm/default.pp
@@ -31,7 +31,7 @@ node 'ubuntucalcite' {
         before => Class['cassandra']
     } ->
     class {'cassandra':
-        package_ensure   => '2.2.5',
+        package_ensure   => '3.0.3',
         cluster_name     => 'CalciteCassandraCluster',
         endpoint_snitch  => 'SimpleSnitch',
         listen_address   => "${::ipaddress_eth0}",


### PR DESCRIPTION
This updates Cassandra to version 3.0.3 (which has materialized view support)
and adds a materialized view to the sample data which can be used for testing.
