### PR TITLE
upgrade druid to 0.9.2 and add swap space to Avoid OOME

### DIFF
--- a/foodmart-dataset/src/main/resources/druid/install.sh
+++ b/foodmart-dataset/src/main/resources/druid/install.sh
@@ -16,30 +16,32 @@
 #
 
 cd ~
+export druid_version=0.9.2
+export zk_version=3.4.6
 
 echo Removing previous Zookeeper
-rm -rf zookeeper-3.4.6
+rm -rf zookeeper-${zk_version}
 
-echo Install and start Zookeeper
+echo "Install and start Zookeeper Version - [${zk_version}]"
 (
- if [ ! -f /var/cache/apt/archives/zookeeper-3.4.6.tar.gz ]; then
-   curl --silent http://www.gtlib.gatech.edu/pub/apache/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz -o /var/cache/apt/archives/zookeeper-3.4.6.tar.gz
+ if [ ! -f /var/cache/apt/archives/zookeeper-${zk_version}.tar.gz ]; then
+   curl --silent http://apache.org/dist/zookeeper/zookeeper-${zk_version}/zookeeper-${zk_version}.tar.gz -o /var/cache/apt/archives/zookeeper-${zk_version}.tar.gz
  fi
- tar -xzf /var/cache/apt/archives/zookeeper-3.4.6.tar.gz
- cd zookeeper-3.4.6
+ tar -xzf /var/cache/apt/archives/zookeeper-${zk_version}.tar.gz
+ cd zookeeper-${zk_version}
  cp conf/zoo_sample.cfg conf/zoo.cfg
  ./bin/zkServer.sh start
 )
 
 echo Removing previous Druid
-rm -rf druid-0.9.1.1
+rm -rf druid-*
 
-echo Installing Druid
-if [ ! -f /var/cache/apt/archives/druid-0.9.1.1-bin.tar.gz ]; then
-  curl --silent http://static.druid.io/artifacts/releases/druid-0.9.1.1-bin.tar.gz -o /var/cache/apt/archives/druid-0.9.1.1-bin.tar.gz
+echo "Installing Druid Version - [${druid_version}]"
+if [ ! -f /var/cache/apt/archives/druid-${druid_version}-bin.tar.gz ]; then
+  curl --silent http://static.druid.io/artifacts/releases/druid-${druid_version}-bin.tar.gz -o /var/cache/apt/archives/druid-${druid_version}-bin.tar.gz
 fi
-tar -xzf /var/cache/apt/archives/druid-0.9.1.1-bin.tar.gz
-cd druid-0.9.1.1
+tar -xzf /var/cache/apt/archives/druid-${druid_version}-bin.tar.gz
+cd druid-${druid_version}
 bin/init
 
 ln -s /dataset/druid/foodmart .

--- a/vm/Vagrantfile
+++ b/vm/Vagrantfile
@@ -64,6 +64,9 @@ Vagrant.configure(2) do |config|
     ubuntucalcite.vm.provision :shell, inline: "cd puppet && librarian-puppet install --verbose"
     ubuntucalcite.vm.provision :shell, inline: "cd puppet && puppet apply -vv --modulepath=modules /vagrant/default.pp"
 
+    # Create Swap space to prevent Out of Memory crashes
+    ubuntucalcite.vm.provision :shell, path: "create_swap.sh"
+
     # Populate MongoDB, Cassandra, Druid, Elasticsearch
     ubuntucalcite.vm.provision :shell, path: "init_mongodb.sh"
     ubuntucalcite.vm.provision :shell, path: "init_cassandra.sh"

--- a/vm/create_swap.sh
+++ b/vm/create_swap.sh
@@ -1,4 +1,19 @@
 #!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # Size of Swap file in Gb
 swapsize=4096

--- a/vm/create_swap.sh
+++ b/vm/create_swap.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Size of Swap file in Gb
+swapsize=4096
+
+# does the swap file already exist?
+grep -q "swapfile" /etc/fstab
+
+# if swap not already created then create it
+if [ $? -ne 0 ]; then
+	echo 'swapfile not found. Adding swapfile.'
+	fallocate -l ${swapsize}M /swapfile
+	chmod 600 /swapfile
+	mkswap /swapfile
+	swapon /swapfile
+	echo '/swapfile none swap defaults 0 0' >> /etc/fstab
+else
+	echo 'swapfile found. No changes made.'
+fi
+
+# output results to terminal
+cat /proc/swaps
+cat /proc/meminfo | grep Swap


### PR DESCRIPTION
This PR has 2 changes - 
1) Update druid version to 0.9.2 
2) Add swap space to avoid OOME errors, NOTE: this slows down the tests a bit. On my machine it now takes about 13 minutes for all druid tests to run. 
Alternatively, we can increase the RAM allocated to the VM to make the tests faster. 