### PR TITLE
Added theta sketch support to food mart in Druid - Needed for [CALCITE-1787] 

### DIFF
--- a/foodmart-dataset/src/main/resources/druid/foodmart/foodmart-index.json
+++ b/foodmart-dataset/src/main/resources/druid/foodmart/foodmart-index.json
@@ -140,7 +140,7 @@
         },
         {
           "name" : "user_unique",
-          "type" : "hyperUnique",
+          "type" : "thetaSketch",
           "fieldName" : "customer_id"
         }
       ]

--- a/foodmart-dataset/src/main/resources/druid/run.sh
+++ b/foodmart-dataset/src/main/resources/druid/run.sh
@@ -25,6 +25,11 @@ function conf() {
 echo Kill existing Druid nodes
 ps aux | grep io.druid.cli.Main | awk '{print $2}' | xargs kill -9
 
+EXTEN_LIST="druid-datasketches"
+
+# Enable the above extension(s)
+echo "druid.extensions.loadList=[\"$EXTEN_LIST\"]" >> conf-quickstart/druid/_common/common.runtime.properties
+
 echo Start Druid historical node
 java `conf historical | xargs` \
     -cp conf-quickstart/druid/_common:conf-quickstart/druid/historical:lib/* \


### PR DESCRIPTION
The edit to the script enables the data sketch extension required for theta sketches, and the change from hyerUnique to thetaSketch lets us query the number of distinct customer_id's with the theta sketch library. More information about data sketches (and theta sketches) for druid and be found here: http://druid.io/docs/latest/development/extensions-core/datasketches-aggregators.html