### PR TITLE
Upgrade to druid 0.11.0

### DIFF
--- a/foodmart-dataset/src/main/resources/druid/install.sh
+++ b/foodmart-dataset/src/main/resources/druid/install.sh
@@ -16,8 +16,8 @@
 #
 
 cd ~
-export druid_version=0.10.0
-export zk_version=3.4.6
+export druid_version=0.11.0-rc2
+export zk_version=3.4.10
 
 echo Removing previous Zookeeper
 rm -rf zookeeper-${zk_version}

--- a/foodmart-dataset/src/main/resources/druid/install.sh
+++ b/foodmart-dataset/src/main/resources/druid/install.sh
@@ -16,7 +16,7 @@
 #
 
 cd ~
-export druid_version=0.11.0-rc2
+export druid_version=0.11.0
 export zk_version=3.4.10
 
 echo Removing previous Zookeeper

--- a/foodmart-dataset/src/main/resources/druid/run.sh
+++ b/foodmart-dataset/src/main/resources/druid/run.sh
@@ -30,6 +30,10 @@ EXTEN_LIST="druid-datasketches"
 # Enable the above extension(s)
 echo "druid.extensions.loadList=[\"$EXTEN_LIST\"]" >> conf-quickstart/druid/_common/common.runtime.properties
 
+# Switch to single threaded groupBy for consistent doubleSum results
+echo "druid.query.groupBy.singleThreaded=true" >> conf-quickstart/druid/_common/common.runtime.properties
+echo "druid.lookup.numLookupLoadingThreads=1" >> conf-quickstart/druid/_common/common.runtime.properties
+
 echo Start Druid historical node
 java `conf historical | xargs` \
     -cp conf-quickstart/druid/_common:conf-quickstart/druid/historical:lib/* \


### PR DESCRIPTION
Upgrade to druid 0.11.0
Note - Right now this is pointing to druid 0.11.0-rc2, will update to 0.11.0 once that gets released. 