### PR TITLE
Fix SafeYaml error with Ubuntu 14.04 and update Vagrant box

### DIFF
--- a/vm/Vagrantfile
+++ b/vm/Vagrantfile
@@ -18,7 +18,7 @@
 
 Vagrant.configure(2) do |config|
   config.vm.box = "puppetlabs/ubuntu-14.04-64-puppet"
-  config.vm.box_url = "https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-puppet/versions/1.0.1/providers/virtualbox.box"
+  config.vm.box_url = "https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-puppet/versions/1.0.3/providers/virtualbox.box"
   config.vm.synced_folder "../foodmart-dataset/target", "/dataset/foodmart"
   config.vm.synced_folder "../zips/src/main/resources/dataset", "/dataset/zips"
   config.vm.synced_folder "../twissandra/src/main/resources/dataset", "/dataset/twissandra"
@@ -67,7 +67,7 @@ Vagrant.configure(2) do |config|
     ubuntucalcite.vm.provision :file, source: "Puppetfile", destination: "/home/vagrant/puppet/Puppetfile"
     ubuntucalcite.vm.provision :file, source: "Puppetfile.lock", destination: "/home/vagrant/puppet/Puppetfile.lock"
     ubuntucalcite.vm.provision :shell, inline: "if [[ ! -f /apt-get-run ]]; then apt-get update && sudo touch /apt-get-run; fi"
-    ubuntucalcite.vm.provision :shell, inline: "apt-get install -y git-core ruby2.0 ruby2.0-dev unzip"
+    ubuntucalcite.vm.provision :shell, inline: "apt-get install -y git-core ruby2.0=2.0.0.484-1ubuntu2 libruby2.0=2.0.0.484-1ubuntu2 ruby2.0-dev=2.0.0.484-1ubuntu2 unzip"
     ubuntucalcite.vm.provision :shell, inline: "gem2.0 install --verbose librarian-puppet"
     ubuntucalcite.vm.provision :shell, inline: "cd puppet && librarian-puppet install --verbose"
     ubuntucalcite.vm.provision :shell, inline: "cd puppet && puppet apply -vv --modulepath=modules /vagrant/default.pp"


### PR DESCRIPTION
There was a bug in Ubuntu 14.04 https://bugs.launchpad.net/ubuntu/+source/ruby2.0/+bug/1777174 that would break the dataset's ability to continue to set up the VM. Also, update the Vagrant Ubuntu 14.04 box to the latest version